### PR TITLE
Make banking data gem mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ rvm:
 script: bundle exec rspec spec
 gemfile:
   - gemfiles/non_BIC.gemfile
+  - gemfiles/BIC_rails_3.gemfile
   - gemfiles/BIC_rails_4.gemfile
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'banking_data', github: 'gapfish/banking_data'

--- a/gemfiles/non_BIC.gemfile
+++ b/gemfiles/non_BIC.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "banking_data", github: "gapfish/banking_data"
 gem "mime-types", "~>1.0"
 
 gemspec path: "../"

--- a/iban-tools.gemspec
+++ b/iban-tools.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   ]
   s.description  = "Validates IBAN account numbers"
 
-  s.add_dependency "banking_data" # from Github, see Gemfile
+  # s.add_dependency "banking_data" # from Github, see Gemfile
 
   s.add_development_dependency "rspec", '~> 3.1'
   s.add_development_dependency "coveralls", '~> 0.7'

--- a/iban-tools.gemspec
+++ b/iban-tools.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   ]
   s.description  = "Validates IBAN account numbers"
 
-  s.add_dependency "banking_data"
+  s.add_dependency "banking_data" # from Github, see Gemfile
 
   s.add_development_dependency "rspec", '~> 3.1'
   s.add_development_dependency "coveralls", '~> 0.7'

--- a/iban-tools.gemspec
+++ b/iban-tools.gemspec
@@ -2,12 +2,11 @@ Gem::Specification.new do |s|
   s.platform     = Gem::Platform::RUBY
   s.summary      = "IBAN validator"
   s.name         = 'iban-tools'
-  s.version      = '1.0.0'
+  s.version      = '1.1.0'
   s.authors      = ["Iulian Dogariu", "Tor Erik Linnerud"]
   s.email        = ["code@iuliandogariu.com", 'tor@alphasights.com']
   s.licenses     = ['MIT']
   s.homepage     = "https://github.com/alphasights/iban-tools"
-  s.requirements << 'none'
   s.require_path = 'lib'
   s.files        = [
     "README.md",
@@ -19,6 +18,8 @@ Gem::Specification.new do |s|
     "lib/iban-tools/rules.yml"
   ]
   s.description  = "Validates IBAN account numbers"
+
+  s.add_dependency "banking_data"
 
   s.add_development_dependency "rspec", '~> 3.1'
   s.add_development_dependency "coveralls", '~> 0.7'

--- a/lib/iban-tools/conversion.rb
+++ b/lib/iban-tools/conversion.rb
@@ -1,3 +1,5 @@
+require 'banking_data'
+
 module IBANTools
   class Conversion
 
@@ -39,7 +41,6 @@ module IBANTools
     end
 
     def self.iban2bic(country_code, bban)
-      require 'banking_data'
       local = iban2local(country_code, bban)
       country = country_code.downcase.to_sym
       blz_attribute =
@@ -56,12 +57,6 @@ module IBANTools
           first
         bic
       end
-    rescue LoadError
-      require 'logger'
-      logger = Logger.new(STDOUT)
-      logger.warn 'You have tried to convert an IBAN to BIC without ' +
-                  'installing the `banking_data` gem'
-      nil
     end
 
     private

--- a/spec/iban-tools/conversion_spec.rb
+++ b/spec/iban-tools/conversion_spec.rb
@@ -171,12 +171,7 @@ module IBANTools
       context 'given valid data' do
         it 'returns valid BIC' do
           bic = Conversion.iban2bic 'DE', '763500000012341234'
-          begin
-            require 'banking_data'
-            bic.should eq('BYLADEM1ERH')
-          rescue LoadError
-            bic.should eq(nil)
-          end
+          bic.should eq('BYLADEM1ERH')
         end
       end
     end


### PR DESCRIPTION
I'm not completely sure if this is the right way to do this, so I tell you the story and you tell me:

I searched where we use the banking_data gem in our mothership and couldn't find the code, however if you remove it, [errors are thrown](https://github.com/gapfish/gapfish/pull/9422). It turned out it was used in one of our dependencies  - [a modified branch of the published gem iban-tools](https://github.com/boostify/iban-tools/tree/banking_data). This modified gem was not specifying and pulling the dependency banking_data itself. [Part of the functionality was relying on it](https://github.com/boostify/iban-tools/blob/1b284b84d8bbab3d1d7454cdbcbf28acadc87d17/lib/iban-tools/conversion.rb#L42), but if it was not installed it didn't throw error, it just returned nil. Only in our system it started throwing errors when it was missing. 

It took me quite some time and the help of Schasse to understand what was happening and that's why I thought it shouldn't be like that. So to clean up the situation I forked the gem, merged the modification branch, which contained the usage of the banking_data gem into master, made the banking_data gem mandatory and declared it as a legitimate dependency, i.e. we can remove it from the user and support gemfile now.

Now we have this fork, which I will then start using in my ruby3 branch. 

I feel this fork is better than a branch with a hidden dependency, but I'm not experienced in the forking business. 

The result looks a little messy to me (not sure, maybe its ok) but that is independent of the above story: Since I'm not using a [published version of the banking_data gem](https://rubygems.org/gems/banking_data) right now, but the[ gapfish-fork](https://github.com/gapfish/banking_data/pull/1), half of the dependencies is now declared in a gemspec and the other half is using a Gemfile (which overwrites the gemspec, if there's conflicts). If we know that we want to keep updating [the original open source repo](https://github.com/opahk/banking_data) and publish the banking_data gem, we could of course use the real gem, that was not clear to me.