### PR TITLE
Add dutch bank account specs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: test
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+
+      - name: Set up gemfiles
+        run: bundle exec appraisal
+
+      - name: Run specs
+        run: |
+          for gemfile in gemfiles/non_BIC.gemfile gemfiles/BIC_rails_3.gemfile gemfiles/BIC_rails_4.gemfile
+            do BUNDLE_GEMFILE=$gemfile bundle install
+              BUNDLE_GEMFILE=$gemfile bundle exec rspec spec
+            done

--- a/Appraisals
+++ b/Appraisals
@@ -1,16 +1,17 @@
 appraise 'non-BIC' do
   gem 'mime-types', '~>1.0' # for coveralls to not cross 1.9.3 requirement
+  gem 'banking_data', github: 'gapfish/banking_data'
 end
 
 appraise 'BIC rails 3' do
   gem 'mime-types', '~>1.0' # for coveralls to not cross 1.9.3 requirement
   gem 'activesupport', '~>3.2.0'
   gem 'activemodel', '~>3.2.0'
-  gem 'banking_data', '~>0.5.0'
+  gem 'banking_data', github: 'gapfish/banking_data'
 end
 
 appraise 'BIC rails 4' do
   gem 'activesupport', '~>4.0.0'
   gem 'activemodel', '~>4.0.0'
-  gem 'banking_data', '~>0.5.0'
+  gem 'banking_data', github: 'gapfish/banking_data'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'banking_data', path: '../banking_data'
-# gem 'banking_data', github: 'gapfish/banking_data' restore once BankingData::DutchBank uses blz

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'banking_data', github: 'gapfish/banking_data'
+gem 'banking_data', path: '../banking_data'
+# gem 'banking_data', github: 'gapfish/banking_data' restore once BankingData::DutchBank uses blz

--- a/gemfiles/BIC_rails_3.gemfile
+++ b/gemfiles/BIC_rails_3.gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 gem "mime-types", "~>1.0"
 gem "activesupport", "~>3.2.0"
 gem "activemodel", "~>3.2.0"
-gem "banking_data", "~>0.5.0"
+gem "banking_data", github: "gapfish/banking_data"
 
 gemspec path: "../"

--- a/gemfiles/BIC_rails_4.gemfile
+++ b/gemfiles/BIC_rails_4.gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "activesupport", "~>4.0.0"
 gem "activemodel", "~>4.0.0"
-gem "banking_data", "~>0.5.0"
+gem "banking_data", github: "gapfish/banking_data"
 
 gemspec path: "../"

--- a/gemfiles/non_BIC.gemfile
+++ b/gemfiles/non_BIC.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "banking_data", github: "gapfish/banking_data"
 gem "mime-types", "~>1.0"
+gem "banking_data", github: "gapfish/banking_data"
 
 gemspec path: "../"

--- a/iban-tools.gemspec
+++ b/iban-tools.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec", '~> 3.1'
   s.add_development_dependency "coveralls", '~> 0.7'
-  s.add_development_dependency "appraisal"
+  s.add_development_dependency "appraisal" # further dependencies in Appraisals
 end

--- a/iban-tools.gemspec
+++ b/iban-tools.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
   s.platform     = Gem::Platform::RUBY
   s.summary      = "IBAN validator"
   s.name         = 'iban-tools'
-  s.version      = '1.1.0'
+  s.version      = '1.1.1'
   s.authors      = ["Iulian Dogariu", "Tor Erik Linnerud"]
   s.email        = ["code@iuliandogariu.com", 'tor@alphasights.com']
   s.licenses     = ['MIT']

--- a/iban-tools.gemspec
+++ b/iban-tools.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |s|
   ]
   s.description  = "Validates IBAN account numbers"
 
-  # s.add_dependency "banking_data" # from Github, see Gemfile
-
   s.add_development_dependency "rspec", '~> 3.1'
   s.add_development_dependency "coveralls", '~> 0.7'
   s.add_development_dependency "appraisal"

--- a/spec/iban-tools/conversion_spec.rb
+++ b/spec/iban-tools/conversion_spec.rb
@@ -174,6 +174,13 @@ module IBANTools
           bic.should eq('BYLADEM1ERH')
         end
       end
+
+      context 'with a dutch bank account' do
+        it "returns valid BIC" do
+          bic = Conversion.iban2bic 'NL', 'INGB1234567890'
+          bic.should eq 'INGBNL2A'
+        end
+      end
     end
 
     describe '::checksum' do


### PR DESCRIPTION
- add `::iban2bic` spec for dutch bank accounts
- use [gapfish/banking_data](https://github.com/gapfish/banking_data) repo instead of upstream gem
- add simple workflow to run specs (without coverage report) on push to this repo